### PR TITLE
Remove unnecessary streaming check

### DIFF
--- a/persona_interact_action/persona_interact_action.jac
+++ b/persona_interact_action/persona_interact_action.jac
@@ -177,16 +177,11 @@ node PersonaInteractAction :InteractAction: {
             return;
         }
 
-        if visitor.streaming {
-            # convey the generator when streaming
-            visitor.generator = model_action_result.get_generator();
-        } else {
-            # set the interaction message when not streaming
-            interaction_message = model_action_result.get_result() or "...";
-            visitor.interaction_node.set_message(
-                TextInteractionMessage(content=interaction_message)
-            );
-        }
+        # set the interaction message
+        interaction_message = model_action_result.get_result() or "...";
+        visitor.interaction_node.set_message(
+            TextInteractionMessage(content=interaction_message)
+        );
     }
 
     can prepare_persona_task_directives(directives:list) -> str{


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
Streaming check in persona action is no longer necessary with new websocket streaming approach for interact walker calls. The generator object was removed from the walker.